### PR TITLE
Issue #2979410: Taxonomy Page Condition not active when views uses same path

### DIFF
--- a/conditions/context_flag_condition.taxonomy_page.inc
+++ b/conditions/context_flag_condition.taxonomy_page.inc
@@ -29,6 +29,12 @@ class ContextFlagTaxonomyPageActive extends ContextFlagBase {
   public function contextFlagConditionCheck() {
     if ($this->condition_used()) {
       $obj_page = menu_get_object('taxonomy_term', 2);
+      if (!isset($obj_page->tid)) {
+        // Try to get it without menu_get_object().
+        if (arg(0) == 'taxonomy' && arg(1) == 'term' && arg(2)) {
+          $obj_page = taxonomy_term_load(arg(2));
+        }
+      }
       if (!empty($obj_page->tid)) {
         $flags = $this->getFlagsForType();
         $arr_flags = array();


### PR DESCRIPTION
See: https://www.drupal.org/project/context_flag/issues/2979410

**Close this PR without merging once patch has been accepted on drupal.org**